### PR TITLE
chore: Update to py-tes 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["snakemake", "plugin", "executor", "tes"]
 python = "^3.11"
 snakemake-interface-common = "^1.14.0"
 snakemake-interface-executor-plugins = "^9.0.0"
-py-tes = "^0.4.2"
+py-tes = "^1.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
I can’t easily test this because https://github.com/snakemake/snakemake/issues/2970 prevents straightforward testing in a virtualenv, and it’s inconvenient to set up a server for the tests to connect to. However, the `py-tes` changelogs,

- https://github.com/ohsu-comp-bio/py-tes/releases/tag/1.1.0-rc.1
- https://github.com/ohsu-comp-bio/py-tes/releases/tag/1.0.0
- https://github.com/ohsu-comp-bio/py-tes/releases/tag/1.1.0

don’t suggest that there should be any incompatibilities from 0.4.x.